### PR TITLE
自动添加apt和router依赖

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+// 自动添加apt和router依赖
+apply plugin: "therouter-starter"
+
 buildscript {
     ext.kotlin_version = '1.5.21'
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }
@@ -16,6 +20,7 @@ buildscript {
 allprojects {
     apply from: "${project.getRootDir()}/therouter.gradle"
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'maven-publish'
 
 group = "cn.therouter"
 
@@ -16,6 +17,14 @@ dependencies {
 repositories {
     mavenCentral()
     google()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
 }
 
 task sourcesJar(type: Jar) {

--- a/plugin/src/main/groovy/com/therouter/plugin/TheRouterStarterPlugin.groovy
+++ b/plugin/src/main/groovy/com/therouter/plugin/TheRouterStarterPlugin.groovy
@@ -44,12 +44,14 @@ public class TheRouterStarterPlugin implements Plugin<Project> {
 
             }
         } else if (isApp || isLib) {
-            proj.configurations.configureEach { Configuration conf ->
-                def confName = conf.name
-                if (confName == KAPT) {
-                    project.dependencies.add(confName, "cn.therouter:apt:$version")
-                } else if (confName == IMPLEMENTATION) {
-                    project.dependencies.add(confName, "cn.therouter:router:$version")
+            proj.with {
+                configurations.configureEach { Configuration conf ->
+                    def confName = conf.name
+                    if (confName == KAPT) {
+                        project.dependencies.add(confName, "cn.therouter:apt:$version")
+                    } else if (confName == IMPLEMENTATION) {
+                        project.dependencies.add(confName, "cn.therouter:router:$version")
+                    }
                 }
             }
         } else {

--- a/plugin/src/main/groovy/com/therouter/plugin/TheRouterStarterPlugin.groovy
+++ b/plugin/src/main/groovy/com/therouter/plugin/TheRouterStarterPlugin.groovy
@@ -1,0 +1,59 @@
+package com.therouter.plugin
+
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+
+public class TheRouterStarterPlugin implements Plugin<Project> {
+    def KAPT = "kapt"
+    def IMPLEMENTATION = "implementation"
+
+    @Override
+    void apply(Project proj) {
+        def isRoot = proj == proj.rootProject
+        def isApp = proj.plugins.hasPlugin(AppPlugin)
+        def isLib = proj.plugins.hasPlugin(LibraryPlugin)
+        def version = proj.rootProject.buildscript.configurations.classpath.dependencies.find {
+            it.group == "cn.therouter" && it.name == "plugin"
+        }?.version
+
+        if (isRoot) {
+            proj.with {
+
+                subprojects {
+
+                    project.plugins.configureEach { Plugin plugin ->
+                        switch (plugin.getClass()) {
+                            case AppPlugin.class:
+                            case LibraryPlugin.class:
+                                project.configurations.configureEach { Configuration conf ->
+                                    def confName = conf.name
+                                    if (confName == KAPT) {
+                                        project.dependencies.add(confName, "cn.therouter:apt:$version")
+                                    } else if (confName == IMPLEMENTATION) {
+                                        project.dependencies.add(confName, "cn.therouter:router:$version")
+                                    }
+                                }
+                                break
+                        }
+                    }
+
+                }
+
+            }
+        } else if (isApp || isLib) {
+            proj.configurations.configureEach { Configuration conf ->
+                def confName = conf.name
+                if (confName == KAPT) {
+                    project.dependencies.add(confName, "cn.therouter:apt:$version")
+                } else if (confName == IMPLEMENTATION) {
+                    project.dependencies.add(confName, "cn.therouter:router:$version")
+                }
+            }
+        } else {
+            throw new RuntimeException("`apply plugin: 'therouter-starter'` must call in rootProject or Android module")
+        }
+    }
+}

--- a/plugin/src/main/resources/META-INF/gradle-plugins/therouter-starter.properties
+++ b/plugin/src/main/resources/META-INF/gradle-plugins/therouter-starter.properties
@@ -1,0 +1,1 @@
+implementation-class=com.therouter.plugin.TheRouterStarterPlugin


### PR DESCRIPTION
只要再项目根`build.gradle` 添加 `apply plugin: "therouter-starter"` 自动给Android模块添加 `kapt "cn.therouter:apt:$TheRouterVersion"` 和 `implementation "cn.therouter:router:$TheRouterVersion"`