### PR TITLE
[fix][消除ksp下的初始冗余]

### DIFF
--- a/agp8-project/plugin/src/main/groovy/com/therouter/plugin/TheRouterInjects.groovy
+++ b/agp8-project/plugin/src/main/groovy/com/therouter/plugin/TheRouterInjects.groovy
@@ -53,9 +53,6 @@ class TheRouterInjects {
                     String className = jarEntry.name.substring(start, end)
                             .replace('\\', '.')
                             .replace('/', '.')
-                    if (className.indexOf('$') > 0) {
-                        className = className.substring(0, className.indexOf('$'))
-                    }
                     InputStream inputStream = file.getInputStream(jarEntry)
                     ClassReader reader = new ClassReader(inputStream)
                     ClassNode cn = new ClassNode()

--- a/apt/src/main/java/com/therouter/ksp/TheRouterSymbolProcessor.kt
+++ b/apt/src/main/java/com/therouter/ksp/TheRouterSymbolProcessor.kt
@@ -138,9 +138,8 @@ class TheRouterSymbolProcessor(
             ps.println(" * JDK Version is ${System.getProperty("java.version")}.")
             ps.println(" */")
             ps.println("@androidx.annotation.Keep")
-            ps.println("class $className : com.therouter.router.IRouterMapAPT {")
+            ps.println("object $className : com.therouter.router.IRouterMapAPT {")
             ps.println()
-            ps.println("\tcompanion object { ")
             ps.println()
             ps.println("\tconst val TAG = \"Created by kymjs, and KSP Version is ${BuildConfig.VERSION}.\"")
             ps.println("\tconst val THEROUTER_APT_VERSION = \"${BuildConfig.VERSION}\"")
@@ -152,13 +151,12 @@ class TheRouterSymbolProcessor(
             var i = 0
             for (item in routePagelist) {
                 i++
-                ps.println("\t\tval item$i = com.therouter.router.RouteItem(\"${item.path}\",\"${item.className}\",\"${item.action}\",\"${item.description}\")")
+                ps.println("\tval item$i = com.therouter.router.RouteItem(\"${item.path}\",\"${item.className}\",\"${item.action}\",\"${item.description}\")")
                 item.params.keys.forEach {
-                    ps.println("\t\titem$i.addParams(\"$it\", \"${item.params[it]}\")")
+                    ps.println("\titem$i.addParams(\"$it\", \"${item.params[it]}\")")
                 }
-                ps.println("\t\tcom.therouter.router.addRouteItem(item$i)")
+                ps.println("\tcom.therouter.router.addRouteItem(item$i)")
             }
-            ps.println("\t}")
             ps.println("\t}")
             ps.println("}")
             ps.flush()
@@ -603,7 +601,7 @@ class TheRouterSymbolProcessor(
             ps.println("@androidx.annotation.Keep")
             ps.println(
                 String.format(
-                    "public class %s : com.therouter.inject.Interceptor {",
+                    "object %s : com.therouter.inject.Interceptor {",
                     className
                 )
             )
@@ -703,25 +701,22 @@ class TheRouterSymbolProcessor(
             ps.println("        return obj")
             ps.println("    }")
             ps.println()
-            ps.println("\tcompanion object { ")
-            ps.println()
             ps.println("\tconst val TAG = \"Created by kymjs, and KSP Version is ${BuildConfig.VERSION}.\"")
             ps.println("\tconst val THEROUTER_APT_VERSION = \"${BuildConfig.VERSION}\"")
             ps.println("\tconst val FLOW_TASK_JSON = \"${stringBuilder}\"")
             ps.println()
-            ps.println("\t\t@kotlin.jvm.JvmStatic")
-            ps.println("\t\tfun addFlowTask(context: android.content.Context, digraph: com.therouter.flow.Digraph) {")
+            ps.println("\t@kotlin.jvm.JvmStatic")
+            ps.println("\tfun addFlowTask(context: android.content.Context, digraph: com.therouter.flow.Digraph) {")
             for (item in flowTaskList) {
-                ps.println("\t\t\tdigraph.addTask(com.therouter.flow.Task(${item.async}, \"${item.taskName}\", \"${item.dependencies}\", object : com.therouter.flow.FlowTaskRunnable {")
-                ps.println("\t\t\t\toverride fun run() = ${item.className}.${item.methodName}(context)")
+                ps.println("\t\tdigraph.addTask(com.therouter.flow.Task(${item.async}, \"${item.taskName}\", \"${item.dependencies}\", object : com.therouter.flow.FlowTaskRunnable {")
+                ps.println("\t\t\toverride fun run() = ${item.className}.${item.methodName}(context)")
                 ps.println()
-                ps.println("\t\t\t\toverride fun log() = \"${item.className}.${item.methodName}(context)\"")
-                ps.println("\t\t\t}))")
+                ps.println("\t\t\toverride fun log() = \"${item.className}.${item.methodName}(context)\"")
+                ps.println("\t\t}))")
             }
             for (item in actionInterceptorList) {
-                ps.println("\t\t\tcom.therouter.TheRouter.addActionInterceptor(\"${item.actionName}\", ${item.className}());")
+                ps.println("\t\tcom.therouter.TheRouter.addActionInterceptor(\"${item.actionName}\", ${item.className}());")
             }
-            ps.println("\t\t}")
             ps.println("\t}")
             ps.println("}")
             ps.flush()

--- a/plugin/src/main/groovy/com/therouter/plugin/TheRouterInjects.groovy
+++ b/plugin/src/main/groovy/com/therouter/plugin/TheRouterInjects.groovy
@@ -53,9 +53,6 @@ class TheRouterInjects {
                     String className = jarEntry.name.substring(start, end)
                             .replace('\\', '.')
                             .replace('/', '.')
-                    if (className.indexOf('$') > 0) {
-                        className = className.substring(0, className.indexOf('$'))
-                    }
                     InputStream inputStream = file.getInputStream(jarEntry)
                     ClassReader reader = new ClassReader(inputStream)
                     ClassNode cn = new ClassNode()


### PR DESCRIPTION
使用 ksp 生成的 ServiceProvider__TheRouter__xxx、 RouterMap__TheRouter__xxx 类中 @JvmStatic 配合内部 companion object 会编译成两个静态函数，导致 TheRouterInjects 收集静态函数时出现冗余。