### PR TITLE
Update DefaultServiceParser.kt

### DIFF
--- a/router/src/main/java/com/therouter/router/autowired/DefaultServiceParser.kt
+++ b/router/src/main/java/com/therouter/router/autowired/DefaultServiceParser.kt
@@ -8,7 +8,7 @@ class DefaultServiceParser : AutowiredParser {
     override fun <T> parse(type: String?, target: Any?, item: AutowiredItem?): T? {
         if (item != null && item.id == 0) {
             try {
-                (Class.forName(item.type) as? Class<T>)?.let { return@let TheRouter.get(it) }
+                (Class.forName(item.type) as? Class<T>)?.let { return TheRouter.get(it) }
             } catch (e: Exception) {
             }
         }


### PR DESCRIPTION
DefaultServiceParser处理使用@AutoWire注解的服务时，无法返回正确的实例
[Demo.zip](https://github.com/HuolalaTech/hll-wp-therouter-android/files/13737259/Demo.zip)
注释掉MainActivity:19 行的 TheRouter.addAutowiredParser(CustomServiceParser()) 可复现此问题