### PR TITLE
修改Navigator.with(Bundle)方法实现, 使其更符合该api签名的第一印象.

### DIFF
--- a/router/src/main/java/com/therouter/router/Navigator.kt
+++ b/router/src/main/java/com/therouter/router/Navigator.kt
@@ -265,7 +265,10 @@ open class Navigator(var url: String?, val intent: Intent?) {
         return this
     }
 
-    fun with(value: Bundle?): Navigator = withBundle(KEY_BUNDLE, value)
+    fun with(value: Bundle?): Navigator {
+        extras.putAll(value)
+        return this
+    }
 
     fun fillParams(action: (Bundle) -> Unit): Navigator {
         action(extras)
@@ -408,14 +411,7 @@ open class Navigator(var url: String?, val intent: Intent?) {
                 navigationIntent.putExtra(KEY_ACTION, routeItem.action)
                 navigationIntent.putExtra(KEY_PATH, getUrlWithParams())
                 navigationIntent.putExtra(KEY_DESCRIPTION, routeItem.description)
-                with(routeItem.getExtras()) {
-                    val bundle: Bundle? = getBundle(KEY_BUNDLE)
-                    if (bundle != null) {
-                        remove(KEY_BUNDLE)
-                        navigationIntent.putExtra(KEY_BUNDLE, bundle)
-                    }
-                    navigationIntent.putExtras(this)
-                }
+                navigationIntent.putExtras(routeItem.getExtras())
                 navigationIntent.addFlags(routeItem.getExtras().getInt(KEY_INTENT_FLAGS))
                 val inAnimId = routeItem.getExtras().getInt(KEY_ANIM_IN)
                 val outAnimId = routeItem.getExtras().getInt(KEY_ANIM_OUT)
@@ -627,14 +623,7 @@ open class Navigator(var url: String?, val intent: Intent?) {
                 intent.putExtra(KEY_ACTION, routeItem.action)
                 intent.putExtra(KEY_PATH, getUrlWithParams())
                 intent.putExtra(KEY_DESCRIPTION, routeItem.description)
-                with(routeItem.getExtras()) {
-                    val bundle: Bundle? = getBundle(KEY_BUNDLE)
-                    if (bundle != null) {
-                        remove(KEY_BUNDLE)
-                        intent.putExtra(KEY_BUNDLE, bundle)
-                    }
-                    intent.putExtras(this)
-                }
+                intent.putExtras(routeItem.getExtras())
                 intent.addFlags(routeItem.getExtras().getInt(KEY_INTENT_FLAGS))
                 if (requestCode == DEFAULT_REQUEST_CODE) {
                     if (fragment != null) {
@@ -702,7 +691,6 @@ open class Navigator(var url: String?, val intent: Intent?) {
 const val KEY_ACTION = "therouter_action"
 const val KEY_PATH = "therouter_path"
 const val KEY_DESCRIPTION = "therouter_description"
-const val KEY_BUNDLE = "therouter_bundle"
 const val KEY_INTENT_FLAGS = "therouter_intent_flags"
 const val KEY_ANIM_IN = "therouter_intent_animation_in"
 const val KEY_ANIM_OUT = "therouter_intent_animation_out"


### PR DESCRIPTION
这个方法给人的第一印象就是把bundle中的参数按Bundle.putAll(Bundle)的方式放到extras中. 如下:
```kotlin
fun with(value: Bundle?): Navigator {
    extras.putAll(value)
    return this
}
```
但其内部实现却是在内部定义了一个KEY把Bundle入参, 存到了这个KEY下. 如下:
```kotlin
const val KEY_BUNDLE = "therouter_bundle"

fun with(value: Bundle?) = = withBundle(KEY_BUNDLE, value)

fun withBundle(key: String?, value: Bundle?): Navigator {
    extras.putBundle(key, value)
    return this
}
```

对于外部调用者来说, 一般情况下并不知道有这个KEY_BUNDLE的键值对. 所以放到extras中的KEY_BUNDLE键值对基本上都是用不到的.

而第一种实现方式, 比较一目了然. 对于外部调用者来说也更加符合自然心理预期.

