### PR TITLE
服务支持个服务提供方,支持通过path获取服务

### DIFF
--- a/apt/src/main/java/com/therouter/apt/ServiceProviderItem.kt
+++ b/apt/src/main/java/com/therouter/apt/ServiceProviderItem.kt
@@ -14,10 +14,12 @@ class ServiceProviderItem(val isMethod: Boolean) : Comparable<ServiceProviderIte
 
     var description = ""
 
+    var path:String =""
+
     var params = ArrayList<String>()
 
     override fun toString(): String {
-        return "ServiceProviderItem(isMethod=$isMethod, element=$element, className='$className', returnType='$returnType', methodName='$methodName', params=$params)"
+        return "ServiceProviderItem(isMethod=$isMethod, element=$element, className='$className', returnType='$returnType', methodName='$methodName', path='$path', params=$params)"
     }
 
     override fun compareTo(other: ServiceProviderItem): Int {

--- a/apt/src/main/java/com/therouter/inject/ServiceProvider.kt
+++ b/apt/src/main/java/com/therouter/inject/ServiceProvider.kt
@@ -14,4 +14,4 @@ import kotlin.reflect.KClass
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
-annotation class ServiceProvider(val returnType: KClass<*> = ServiceProvider::class, val params: Array<KClass<*>> = [])
+annotation class ServiceProvider(val returnType: KClass<*> = ServiceProvider::class, val path: String = "", val params: Array<KClass<*>> = [])

--- a/apt/src/main/java/com/therouter/ksp/TheRouterSymbolProcessor.kt
+++ b/apt/src/main/java/com/therouter/ksp/TheRouterSymbolProcessor.kt
@@ -374,7 +374,9 @@ class TheRouterSymbolProcessor(
                                 }
                             }
                         }
-
+                        "path" -> {
+                            serviceProviderItem.path = arg.value.toString()
+                        }
                         "params" -> {
                             val params = ArrayList<String>()
                             for (kv in arg.value as List<*>) {
@@ -452,7 +454,9 @@ class TheRouterSymbolProcessor(
                                 }
                             }
                         }
-
+                        "path" -> {
+                            serviceProviderItem.path = arg.value.toString()
+                        }
                         "params" -> {
                             val params = ArrayList<String>()
                             for (kv in arg.value as List<*>) {
@@ -645,8 +649,11 @@ class TheRouterSymbolProcessor(
             } catch (e: Exception) {
             }
             for (serviceProviderItem in pageList) {
-                //处理 USE_EXTEND 开关
-                if (STR_TRUE.equals(prop.getProperty(KEY_USE_EXTEND), ignoreCase = true)) {
+                val isPathService = serviceProviderItem.path.isNotBlank()
+                if (isPathService) {
+                    ps.print(String.format("if (clazz === Any::class.java && params.size >0 && \"%s\" == params[0]", serviceProviderItem.path.replace("\"","\\\"")))
+                } else if (STR_TRUE.equals(prop.getProperty(KEY_USE_EXTEND), ignoreCase = true)) {
+                    //处理 USE_EXTEND 开关
                     ps.print(
                         String.format(
                             "if (%s::class.javaObjectType.isAssignableFrom(clazz)",
@@ -663,14 +670,15 @@ class TheRouterSymbolProcessor(
                 }
                 // 多参数判断
                 ps.print(" && params.size == ")
+                val offsetCount = if (isPathService) 1 else 0
                 if (serviceProviderItem.params.size == 1) {
                     if (serviceProviderItem.params[0].trim { it <= ' ' }.isEmpty()) {
-                        ps.print(0)
+                        ps.print(0 + offsetCount)
                     } else {
-                        ps.print(1)
+                        ps.print(1 + offsetCount)
                     }
                 } else {
-                    ps.print(serviceProviderItem.params.size)
+                    ps.print(serviceProviderItem.params.size + offsetCount)
                 }
                 //参数类型判断
                 for (count in serviceProviderItem.params.indices) {
@@ -679,7 +687,7 @@ class TheRouterSymbolProcessor(
                             String.format(
                                 Locale.getDefault(),
                                 "\n\t\t\t\t&& params[%d] is %s",
-                                count,
+                                count + offsetCount,
                                 serviceProviderItem.params[count]
                             )
                         )
@@ -712,7 +720,7 @@ class TheRouterSymbolProcessor(
                             String.format(
                                 Locale.getDefault(),
                                 "params[%d] as %s",
-                                count,
+                                count + offsetCount,
                                 serviceProviderItem.params[count]
                             )
                         )

--- a/business-b/src/main/java/com/therouter/demo/b/PushAdService.java
+++ b/business-b/src/main/java/com/therouter/demo/b/PushAdService.java
@@ -1,0 +1,12 @@
+package com.therouter.demo.b;
+
+import com.therouter.demo.di.IPushService;
+import com.therouter.inject.ServiceProvider;
+
+@ServiceProvider(path = "/push/ad")
+public class PushAdService implements IPushService {
+    @Override
+    public void onPush(String jsonStr) {
+
+    }
+}

--- a/business-b/src/main/java/com/therouter/demo/b/PushOpusService.java
+++ b/business-b/src/main/java/com/therouter/demo/b/PushOpusService.java
@@ -1,0 +1,11 @@
+package com.therouter.demo.b;
+
+import com.therouter.demo.di.IPushService;
+import com.therouter.inject.ServiceProvider;
+
+@ServiceProvider(path = "/push/opus")
+public class PushOpusService implements IPushService {
+    @Override
+    public void onPush(String jsonStr) {
+    }
+}

--- a/business-b/src/main/java/com/therouter/demo/b/PushVideoService.java
+++ b/business-b/src/main/java/com/therouter/demo/b/PushVideoService.java
@@ -1,0 +1,12 @@
+package com.therouter.demo.b;
+
+import com.therouter.demo.di.IPushService;
+import com.therouter.inject.ServiceProvider;
+
+@ServiceProvider(path = "/push/video")
+public class PushVideoService implements IPushService {
+    @Override
+    public void onPush(String jsonStr) {
+
+    }
+}

--- a/business-b/src/main/java/com/therouter/demo/b/Test.java
+++ b/business-b/src/main/java/com/therouter/demo/b/Test.java
@@ -1,5 +1,6 @@
 package com.therouter.demo.b;
 
+import com.therouter.demo.di.IPushService;
 import com.therouter.demo.di.IUserService;
 import com.therouter.inject.ServiceProvider;
 
@@ -16,6 +17,28 @@ public class Test {
             @Override
             public String getUserInfo() {
                 return "这是用户信息";
+            }
+        };
+    }
+
+    @ServiceProvider(path =  "/push/demo")
+    public static IPushService demo() {
+        return new IPushService() {
+
+            @Override
+            public void onPush(String jsonStr) {
+
+            }
+        };
+    }
+
+    @ServiceProvider(path =  "/push/str")
+    public static IPushService demo(String str) {
+        return new IPushService() {
+
+            @Override
+            public void onPush(String jsonStr) {
+
             }
         };
     }

--- a/business-base/src/main/java/com/therouter/demo/di/IPushService.java
+++ b/business-base/src/main/java/com/therouter/demo/di/IPushService.java
@@ -1,0 +1,5 @@
+package com.therouter.demo.di;
+
+public interface IPushService {
+    void onPush(String jsonStr);
+}

--- a/router/src/main/java/com/therouter/TheRouter.kt
+++ b/router/src/main/java/com/therouter/TheRouter.kt
@@ -179,6 +179,14 @@ object TheRouter {
     }
 
     /**
+     * 通过路由path获取跨模块依赖的服务
+     */
+    @JvmStatic
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(path:String,vararg params: Any?): T? {
+        return routerInject.get(Any::class.java, path, *params) as T
+    }
+    /**
      * 通过Path构建路由导航器
      */
     @JvmStatic

--- a/router/src/main/java/com/therouter/inject/ServiceProvider.kt
+++ b/router/src/main/java/com/therouter/inject/ServiceProvider.kt
@@ -14,4 +14,4 @@ import kotlin.reflect.KClass
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
-annotation class ServiceProvider(val returnType: KClass<*> = ServiceProvider::class, val params: Array<KClass<*>> = [])
+annotation class ServiceProvider(val returnType: KClass<*> = ServiceProvider::class, val path: String = "", val params: Array<KClass<*>> = [])


### PR DESCRIPTION
兼容Arouter的写法
```
helloService1 = (HelloService) ARouter.getInstance().build("/test/helloworld").navigation();
helloService2 = (HelloService) ARouter.getInstance().build("/test/helloandroid").navigation();
```
可以用路由表示相同服务的不同的提供方
```
IPushService a =  TheRouter.get("/push/ad");
IPushService b =  TheRouter.get("/push/opus");
IPushService c =  TheRouter.get("/push/vidoe");
IPushService d =  TheRouter.get("/push/demo");
IPushService e =  TheRouter.get("/push/str","test");
```