### PR TITLE
fix:部分场景下增量模式未能更新路由配置问题

### DIFF
--- a/plugin/src/main/groovy/com/therouter/plugin/AddCodeVisitor.java
+++ b/plugin/src/main/groovy/com/therouter/plugin/AddCodeVisitor.java
@@ -36,7 +36,8 @@ public class AddCodeVisitor extends ClassVisitor {
     @Override
     public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
         if ("asm".equals(name) && "Z".equals(descriptor)) {
-            return super.visitField(access, name, descriptor, signature, true);
+            boolean hasData = !serviceProvideList.isEmpty() || !autowiredList.isEmpty() || !routeList.isEmpty();
+            return super.visitField(access, name, descriptor, signature, hasData);
         }
         return super.visitField(access, name, descriptor, signature, value);
     }

--- a/plugin/src/main/groovy/com/therouter/plugin/TheRouterPlugin.groovy
+++ b/plugin/src/main/groovy/com/therouter/plugin/TheRouterPlugin.groovy
@@ -17,6 +17,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 
+import java.security.MessageDigest
+
 public class TheRouterPlugin implements Plugin<Project> {
     public static final String WARNING = "warning";
     public static final String ERROR = "error";
@@ -94,6 +96,7 @@ public class TheRouterPlugin implements Plugin<Project> {
                         @Override
                         public Unit invoke(TextParameters textParameters) {
                             textParameters.getTheRouterBuildFolder().set(therouterBuildFolder);
+                            textParameters.getCacheContentHash().set(computeCacheHash(therouterBuildFolder));
                             return null;
                         }
                     });
@@ -134,6 +137,21 @@ public class TheRouterPlugin implements Plugin<Project> {
                 }
             }
         });
+    }
+
+    private static String computeCacheHash(File therouterBuildFolder) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5")
+            ["serviceProvide.therouter", "autowired.therouter", "route.therouter"].each { name ->
+                File f = new File(therouterBuildFolder, name)
+                if (f.exists()) {
+                    md.update(f.bytes)
+                }
+            }
+            return md.digest().encodeHex().toString()
+        } catch (Exception e) {
+            return "empty"
+        }
     }
 
     def getGradleProperties(Project project) {

--- a/plugin/src/main/groovy/com/therouter/plugin/agp8/TextParameters.java
+++ b/plugin/src/main/groovy/com/therouter/plugin/agp8/TextParameters.java
@@ -10,4 +10,7 @@ import java.io.File;
 public interface TextParameters extends InstrumentationParameters {
     @Input
     Property<File> getTheRouterBuildFolder();
+
+    @Input
+    Property<String> getCacheContentHash();
 }


### PR DESCRIPTION
解决 [issue285](https://github.com/HuolalaTech/hll-wp-therouter-android/issues/285) 提到的问题

修复 forceIncremental 模式下 TheRouterServiceProvideInjecter 字节码注入失败       
当 forceIncremental=true 时，字节码注入分两阶段执行：                                                                                                        
1. TheRouterASM（AsmClassVisitorFactory）读取缓存文件，注入字节码                                                                                            
2. TheRouterGetAllTask 扫描所有 class，写入缓存文件                                                                                                          
                                                                                                                                                             
问题：                                                                                                                                                       
- 首次构建时缓存文件不存在，ClassCacheUtils.readToMap() 返回空集合（不抛异常），导致 AddCodeVisitor 注入空方法体但仍设置 asm=true                            
- AGP 缓存了 AsmClassVisitorFactory 的转换结果，后续构建不再重新调用 createClassVisitor()，因为 TextParameters 仅用 @Input                                   
追踪缓存目录路径，未追踪缓存文件内容变化                                                                                                                     
- 结果：asm=true 阻止了反射回退，空方法体导致路由完全失效                                                                                                    
                                                                                                                                                             
修复方案（两处改动）                                                                                                                                         
                                                                                                                                                             
改动 1：让 AGP 感知缓存内容变化                                                                                                                              
                                                                                                                                                             
在 TextParameters 中增加缓存内容哈希作为 @Input，当缓存文件内容变化时 AGP 自动重新执行 TheRouterASM。                                                        
                                                                                                                                                             
文件：plugin/src/main/groovy/com/therouter/plugin/agp8/TextParameters.java                                                                                   
- 新增 @Input Property<String> getCacheContentHash()                                                                                                         
                                                                                                                                                             
文件：plugin/src/main/groovy/com/therouter/plugin/TheRouterPlugin.groovy                                                                                     
- 在配置 TextParameters 时，读取三个 .therouter 缓存文件内容，计算哈希值传入                                                                                 
                                                                                                                                                             
改动 2：缓存为空时不设置 asm=true                                                                                                                            
                                                                                                                                                             
当三个集合全为空时，asm 保持 false，让运行时走反射回退逻辑（首次构建可正常工作）。                                                                           
                                                                                                                                                             
文件：plugin/src/main/groovy/com/therouter/plugin/AddCodeVisitor.java                                                                                        
- visitField() 中，仅当集合非空时才将 asm 设为 true     
