### PR TITLE
开启forceIncremental在clean后首次构建，TheRouterServiceProvideInjecter代码生成异常

### DIFF
--- a/plugin/src/main/groovy/com/therouter/plugin/TheRouterPlugin.groovy
+++ b/plugin/src/main/groovy/com/therouter/plugin/TheRouterPlugin.groovy
@@ -10,6 +10,7 @@ import com.therouter.plugin.agp8.TextParameters
 import com.therouter.plugin.agp8.TheRouterASM
 import com.therouter.plugin.agp8.TheRouterGetAllTask
 import com.therouter.plugin.agp8.TheRouterTask
+import com.therouter.plugin.utils.ClassCacheUtils
 import kotlin.Unit
 import kotlin.jvm.functions.Function1
 import org.gradle.api.Action
@@ -57,7 +58,7 @@ public class TheRouterPlugin implements Plugin<Project> {
                     cachePath = new File(project.getRootDir(), theRouterExtension.incrementalCachePath).getAbsolutePath();
                 }
                 final File therouterBuildFolder = new File(cachePath, "therouter");
-                boolean isIncremental = theRouterExtension.forceIncremental || (theRouterExtension.debug && therouterBuildFolder.exists());
+                boolean isIncremental = (theRouterExtension.forceIncremental || theRouterExtension.debug) && isCacheReady(therouterBuildFolder);
                 if (!isShow) {
                     isShow = true;
                     System.out.println();
@@ -139,10 +140,22 @@ public class TheRouterPlugin implements Plugin<Project> {
         });
     }
 
+    private static boolean isCacheReady(File dir) {
+        if (dir == null || !dir.exists()) return false
+        return hasCacheFile(dir, ClassCacheUtils.CACHE_SERVICE_PROVIDE)
+                && hasCacheFile(dir, ClassCacheUtils.CACHE_AUTOWIRED)
+                && hasCacheFile(dir, ClassCacheUtils.CACHE_ROUTE)
+    }
+
+    private static boolean hasCacheFile(File dir, String name) {
+        File f = new File(dir, name)
+        return f.isFile() && f.canRead()
+    }
+
     private static String computeCacheHash(File therouterBuildFolder) {
         try {
             MessageDigest md = MessageDigest.getInstance("MD5")
-            ["serviceProvide.therouter", "autowired.therouter", "route.therouter"].each { name ->
+            [ClassCacheUtils.CACHE_SERVICE_PROVIDE, ClassCacheUtils.CACHE_AUTOWIRED, ClassCacheUtils.CACHE_ROUTE].each { name ->
                 File f = new File(therouterBuildFolder, name)
                 if (f.exists()) {
                     md.update(f.bytes)

--- a/plugin/src/main/groovy/com/therouter/plugin/agp8/TheRouterASM.java
+++ b/plugin/src/main/groovy/com/therouter/plugin/agp8/TheRouterASM.java
@@ -20,9 +20,9 @@ public abstract class TheRouterASM implements AsmClassVisitorFactory<TextParamet
     public ClassVisitor createClassVisitor(ClassContext classContext, ClassVisitor classVisitor) {
         File therouterBuildFolder = getParameters().get().getTheRouterBuildFolder().get();
         try {
-            Map<String, String> serviceProvideMap = ClassCacheUtils.readToMap(new File(therouterBuildFolder, "serviceProvide.therouter"));
-            Set<String> autowiredSet = ClassCacheUtils.readToSet(new File(therouterBuildFolder, "autowired.therouter"));
-            Set<String> routeSet = ClassCacheUtils.readToSet(new File(therouterBuildFolder, "route.therouter"));
+            Map<String, String> serviceProvideMap = ClassCacheUtils.readToMap(new File(therouterBuildFolder, ClassCacheUtils.CACHE_SERVICE_PROVIDE));
+            Set<String> autowiredSet = ClassCacheUtils.readToSet(new File(therouterBuildFolder, ClassCacheUtils.CACHE_AUTOWIRED));
+            Set<String> routeSet = ClassCacheUtils.readToSet(new File(therouterBuildFolder, ClassCacheUtils.CACHE_ROUTE));
             return new AddCodeVisitor(classVisitor, serviceProvideMap, autowiredSet, routeSet, false);
         } catch (IOException e) {
             return classVisitor;

--- a/plugin/src/main/groovy/com/therouter/plugin/agp8/TheRouterGetAllTask.java
+++ b/plugin/src/main/groovy/com/therouter/plugin/agp8/TheRouterGetAllTask.java
@@ -251,9 +251,9 @@ public abstract class TheRouterGetAllTask extends DefaultTask {
             }
         }
 
-        boolean change1 = ClassCacheUtils.write(TheRouterInjects.serviceProvideMap.keySet(), new File(therouterBuildFolder, "serviceProvide.therouter"));
-        boolean change2 = ClassCacheUtils.write(TheRouterInjects.autowiredSet, new File(therouterBuildFolder, "autowired.therouter"));
-        boolean change3 = ClassCacheUtils.write(TheRouterInjects.routeSet, new File(therouterBuildFolder, "route.therouter"));
+        boolean change1 = ClassCacheUtils.write(TheRouterInjects.serviceProvideMap.keySet(), new File(therouterBuildFolder, ClassCacheUtils.CACHE_SERVICE_PROVIDE));
+        boolean change2 = ClassCacheUtils.write(TheRouterInjects.autowiredSet, new File(therouterBuildFolder, ClassCacheUtils.CACHE_AUTOWIRED));
+        boolean change3 = ClassCacheUtils.write(TheRouterInjects.routeSet, new File(therouterBuildFolder, ClassCacheUtils.CACHE_ROUTE));
         if (change1 || change2 || change3) {
             onCacheChange();
         }

--- a/plugin/src/main/groovy/com/therouter/plugin/utils/ClassCacheUtils.java
+++ b/plugin/src/main/groovy/com/therouter/plugin/utils/ClassCacheUtils.java
@@ -16,14 +16,18 @@ import java.util.Set;
 
 public class ClassCacheUtils {
 
+    public static final String CACHE_SERVICE_PROVIDE = "serviceProvide.therouter";
+    public static final String CACHE_AUTOWIRED = "autowired.therouter";
+    public static final String CACHE_ROUTE = "route.therouter";
+
     public static boolean write(Set<String> set, File file) throws IOException {
         String content = set2String(set);
-        String cache = set2String(readToSet(file));
-        if (content.equals(cache)) {
-            // 缓存没变化
-            return false;
-        }
         if (file.exists()) {
+            // 文件已存在时才做"内容无变化"的跳过优化
+            String cache = set2String(readToSet(file));
+            if (content.equals(cache)) {
+                return false;
+            }
             file.delete();
         }
         if (!file.getParentFile().exists()) {


### PR DESCRIPTION
### 背景&复现步骤（必现）
问题版本：`1.3.2`
当在 app 工程 `build.gradle` （demo 中是 `agp8-build.gradle`）中开启 `forceIncremental`，即 TheRouter 插件配置如下：
```
TheRouter {
    forceIncremental = true
    incrementalCachePath = "/app/build"
}
```
然后执行 `./gradlew clean` 再进行打包，反编译生成的 APK 中`TheRouterServiceProvideInjecter` 的所有方法体均为空，且变量`asm = false`：
```
public final class TheRouterServiceProvideInjecter {
    @Keep
    public static boolean asm = false;

    // addFlowTask、initDefaultRouteMap、trojan 等方法体全部为空
}
```
<img width="1422" height="667" alt="增量构建" src="https://github.com/user-attachments/assets/94dccb74-dc95-4999-9445-34a83e4b5e41" />



而注释掉上述 `TheRouter {} `配置后，相同工程打出的包 `asm = true`，`trojan() `等方法体包含完整的路由注入代码。
```
public final class TheRouterServiceProvideInjecter {
    @Keep
    public static boolean asm = true;

    // trojan 等方法体包含完整的路由注入代码
}
```
<img width="2106" height="1289" alt="无增量构建" src="https://github.com/user-attachments/assets/6ce52d39-a971-4ea6-9499-adbe8b04a7e0" />



这意味着开启 `forceIncremental` 且 clean 后，首次构建时，所有路由跳转、ServiceProvider、FlowTask 在运行时全部失效（非反射兜底），不符合预期。

### 原因
增量编译路径下，插件注册了两个组件：
TheRouterASM（AsmClassVisitorFactory）、TheRouterGetAllTask。即在同一次构建内：ASM 读取的是上一次构建写下的缓存，GetAllTask 写入的缓存供下一次构建使用。

修复前的判断逻辑：
```
// 修复前
boolean isIncremental = theRouterExtension.forceIncremental
        || (theRouterExtension.debug && therouterBuildFolder.exists());
```
debug 模式有存在性保护（`therouterBuildFolder.exists()`），但 `forceIncremental = true` 条件却完全绕过了这个检查，无论缓存是否存在都强制走增量构建路径。

`.gradlew clean `会删除 build/ 目录，*.therouter 缓存文件随之消失。此后首次构建：
1.  forceIncremental = true → isIncremental = true（缓存文件已不存在）
2. TheRouterASM 读取不存在的缓存文件 → 三个集合全为空
3. AddCodeVisitor.visitField：hasData = false → asm = false，方法注入循环无内容
4. TheRouterGetAllTask 在编译结束后才写入缓存，但本次插桩已完成

### 修复内容
1. 核心 Bug 修复（TheRouterPlugin.groovy）
引入 isCacheReady() 替代单纯的目录存在性检查，要求三个缓存文件均存在且可读才启用增量构建：
```
// 修复前
boolean isIncremental = theRouterExtension.forceIncremental
        || (theRouterExtension.debug && therouterBuildFolder.exists());
```

```
// 修复后
boolean isIncremental = (theRouterExtension.forceIncremental || theRouterExtension.debug) && isCacheReady(therouterBuildFolder);

private static boolean isCacheReady(File dir) {
      if (dir == null || !dir.exists()) return false
      return hasCacheFile(dir, ClassCacheUtils.CACHE_SERVICE_PROVIDE)
              && hasCacheFile(dir, ClassCacheUtils.CACHE_AUTOWIRED)
              && hasCacheFile(dir, ClassCacheUtils.CACHE_ROUTE)
}

private static boolean hasCacheFile(File dir, String name) {
      File f = new File(dir, name)
      return f.isFile() && f.canRead()
}

```
isIncremental 需保证 therouterBuildFolder 存在。

2. 提取缓存文件名常量（ClassCacheUtils.java）
将多处散落在 TheRouterPlugin、TheRouterASM、TheRouterGetAllTask 中的硬编码字符串统一提取到 `ClassCacheUtils`：
```
public static final String CACHE_SERVICE_PROVIDE = "serviceProvide.therouter";
public static final String CACHE_AUTOWIRED       = "autowired.therouter";
public static final String CACHE_ROUTE           = "route.therouter";
```